### PR TITLE
Fixing an issue when adding nested elements

### DIFF
--- a/Plivo/PlivoXML.cs
+++ b/Plivo/PlivoXML.cs
@@ -84,7 +84,7 @@ namespace Plivo.XML
             if (posn >= 0)
             {
                 Element.Add(element.Element);
-                return this;
+                return element;
             }
             else
                 throw new PlivoException(String.Format("Element {0} cannot be nested within {1}", element.GetType().Name, this.GetType().Name));


### PR DESCRIPTION
Calling a method to add a nested element returns the parent element, and not the newly nested element.  This makes it impossible to reference the newly created element and makes all of the helper functions (like AddDial) useless because you have to new up a Dial element to have access to it anyway.

Fix is to return the nested element instead of 'this'.
