### PR TITLE
feat: add number_of_employees field to Profile API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## [5.52.2](https://github.com/plivo/plivo-dotnet/tree/v5.52.2) (2026-06-10)
+**Feature - Profile API number of employees field support**
+- Added Number of Employees field support to Profile API
+
 ## [5.52.1](https://github.com/plivo/plivo-dotnet/tree/v5.52.1) (2026-05-26)
 **Feature - Profile API DBA field support**
 - Added Doing Business As (DBA) field support to Profile API

--- a/src/Plivo/Plivo.csproj
+++ b/src/Plivo/Plivo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.3</TargetFrameworks>
-    <ReleaseVersion>5.52.1</ReleaseVersion>
+    <ReleaseVersion>5.52.2</ReleaseVersion>
     <Version />
     <Authors>Plivo SDKs Team</Authors>
     <Owners>Plivo Inc.</Owners>

--- a/src/Plivo/Plivo.nuspec
+++ b/src/Plivo/Plivo.nuspec
@@ -4,7 +4,7 @@
     <summary>A .NET SDK to make voice calls and send SMS using Plivo and to generate Plivo XML</summary>
     <description>A .NET SDK to make voice calls and send SMS using Plivo and to generate Plivo XML</description>
     <id>Plivo</id>
-    <version>5.52.1</version>
+    <version>5.52.2</version>
     <title>Plivo</title>
     <authors>Plivo SDKs Team</authors>
     <owners>Plivo, Inc.</owners>

--- a/src/Plivo/Resource/Profile/Profile.cs
+++ b/src/Plivo/Resource/Profile/Profile.cs
@@ -131,6 +131,12 @@ namespace Plivo.Resource.Profile
         [JsonProperty("doing_business_as")]
         public string DoingBusinessAs { get; set; }
 
+        // Allowed values (server-validated, not enforced client-side):
+        // BETWEEN_1_AND_10, BETWEEN_11_AND_50, BETWEEN_51_AND_200, BETWEEN_201_AND_500,
+        // BETWEEN_501_AND_2000, BETWEEN_2001_AND_10000, MORE_THAN_10001
+        [JsonProperty("number_of_employees")]
+        public string NumberOfEmployees { get; set; }
+
     }
 
     [JsonObject(MemberSerialization.OptIn)]
@@ -198,6 +204,12 @@ namespace Plivo.Resource.Profile
 
         [JsonProperty("doing_business_as")]
         public string DoingBusinessAs { get; set; }
+
+        // Allowed values (server-validated, not enforced client-side):
+        // BETWEEN_1_AND_10, BETWEEN_11_AND_50, BETWEEN_51_AND_200, BETWEEN_201_AND_500,
+        // BETWEEN_501_AND_2000, BETWEEN_2001_AND_10000, MORE_THAN_10001
+        [JsonProperty("number_of_employees")]
+        public string NumberOfEmployees { get; set; }
 
         public override string ToString()
         {

--- a/src/Plivo/Resource/Profile/ProfileInterface.cs
+++ b/src/Plivo/Resource/Profile/ProfileInterface.cs
@@ -124,7 +124,7 @@ namespace Plivo.Resource.Profile
 
         public ProfileResponse Create(string profile_alias, string plivo_subaccount,  string customer_type,
             string entity_type, string company_name,  string ein, string vertical,
-            string ein_issuing_country, string stock_symbol, string stock_exchange, string website,string alt_business_id, string alt_business_id_type, AuthorizedContact authorized_contact, Address address, string business_contact_email = null, string doing_business_as = null)
+            string ein_issuing_country, string stock_symbol, string stock_exchange, string website,string alt_business_id, string alt_business_id_type, AuthorizedContact authorized_contact, Address address, string business_contact_email = null, string doing_business_as = null, string number_of_employees = null)
         {
         var mandatoryParams = new List<string>{"profile_alias"};
         Console.WriteLine(entity_type);
@@ -148,7 +148,8 @@ namespace Plivo.Resource.Profile
                 address,
                 website,
                 business_contact_email,
-                doing_business_as
+                doing_business_as,
+                number_of_employees
             });
 		return ExecuteWithExceptionUnwrap(() =>
 		{
@@ -179,7 +180,7 @@ namespace Plivo.Resource.Profile
         /// <param name="business_contact_email">business_contact_email</param>
 		public async Task<ProfileResponse> CreateAsync(string profile_alias, string plivo_subaccount,  string customer_type,
             string entity_type, string company_name,  string ein, string vertical, string website,
-            string ein_issuing_country, string stock_symbol, string stock_exchange, string alt_business_id, string alt_business_id_type, AuthorizedContact authorized_contact, Address address, string business_contact_email = null, string doing_business_as = null)
+            string ein_issuing_country, string stock_symbol, string stock_exchange, string alt_business_id, string alt_business_id_type, AuthorizedContact authorized_contact, Address address, string business_contact_email = null, string doing_business_as = null, string number_of_employees = null)
 		{
          var mandatoryParams = new List<string>{"profile_alias"};
           var data = CreateData(
@@ -202,7 +203,8 @@ namespace Plivo.Resource.Profile
                 address,
                 website,
                 business_contact_email,
-                doing_business_as
+                doing_business_as,
+                number_of_employees
             });
 			var result = await Client.Update<ProfileResponse>(Uri + "Profile/", data);
             result.Object.StatusCode = result.StatusCode;
@@ -227,7 +229,7 @@ namespace Plivo.Resource.Profile
 
         public GetProfile Update(string profile_uuid, string company_name =null,  string website = null,
             string entity_type=null, string vertical= null,  AuthorizedContact authorized_contact=null, Address address=null, string business_contact_email = null,
-            string ein = null, string ein_issuing_country = null, string alt_business_id = null, string alt_business_id_type = null, string doing_business_as = null)
+            string ein = null, string ein_issuing_country = null, string alt_business_id = null, string alt_business_id_type = null, string doing_business_as = null, string number_of_employees = null)
         {
              var mandatoryParams = new List<string>{"profile_uuid"};
         var data = CreateData(
@@ -245,7 +247,8 @@ namespace Plivo.Resource.Profile
                 ein_issuing_country,
                 alt_business_id,
                 alt_business_id_type,
-                doing_business_as
+                doing_business_as,
+                number_of_employees
             });
 		return ExecuteWithExceptionUnwrap(() =>
 		{
@@ -270,7 +273,7 @@ namespace Plivo.Resource.Profile
         /// <param name="business_contact_email">business_contact_email</param>
 		public async Task<ProfileResponse> UpdateAsync(string profile_uuid, string company_name =null,  string website = null,
             string entity_type=null, string vertical= null,  AuthorizedContact authorized_contact=null, Address address=null, string business_contact_email = null,
-            string ein = null, string ein_issuing_country = null, string alt_business_id = null, string alt_business_id_type = null, string doing_business_as = null)
+            string ein = null, string ein_issuing_country = null, string alt_business_id = null, string alt_business_id_type = null, string doing_business_as = null, string number_of_employees = null)
         {
              var mandatoryParams = new List<string>{"profile_uuid"};
         var data = CreateData(
@@ -288,7 +291,8 @@ namespace Plivo.Resource.Profile
                 ein_issuing_country,
                 alt_business_id,
                 alt_business_id_type,
-                doing_business_as
+                doing_business_as,
+                number_of_employees
             });
 			var result = await Client.Update<ProfileResponse>(Uri + "Profile/"+profile_uuid+"/", data);
             result.Object.StatusCode = result.StatusCode;

--- a/tests_netcore/Plivo.NetCore.Test/Mocks/profileGetResponse.json
+++ b/tests_netcore/Plivo.NetCore.Test/Mocks/profileGetResponse.json
@@ -30,6 +30,7 @@
         "stock_symbol": "ABC",
         "vertical": "PROFESSIONAL",
         "website": "google.com",
-        "doing_business_as": "ABC DBA"
+        "doing_business_as": "ABC DBA",
+        "number_of_employees": "BETWEEN_1_AND_10"
     }
 }

--- a/tests_netcore/Plivo.NetCore.Test/Resources/TestProfile.cs
+++ b/tests_netcore/Plivo.NetCore.Test/Resources/TestProfile.cs
@@ -53,6 +53,7 @@ namespace Plivo.NetCore.Test.Resources
             );
             var resp =  Api.Profile.Get(id);
             Assert.Equal("ABC DBA", resp.Profile.DoingBusinessAs);
+            Assert.Equal("BETWEEN_1_AND_10", resp.Profile.NumberOfEmployees);
             AssertRequest(request);
         }
     }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.52.1",
+  "version": "5.52.2",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
## Summary
Adds the optional `number_of_employees` field to the Profile (10DLC/A2P account profile) create and update APIs, mirroring the backend campaign-service change. Modeled exactly on the recently added `doing_business_as` (DBA) field.

- New `NumberOfEmployees` property (`[JsonProperty("number_of_employees")]`) on both the `Profile` and `ListProfiles` response models, added right after `DoingBusinessAs`.
- New optional `number_of_employees` string parameter on `Create`, `CreateAsync`, `Update`, and `UpdateAsync`, threaded through each `CreateData` payload right after `doing_business_as`.
- Optional string with NO client-side enum validation (server validates). Allowed values are documented in a comment, not enforced: `BETWEEN_1_AND_10`, `BETWEEN_11_AND_50`, `BETWEEN_51_AND_200`, `BETWEEN_201_AND_500`, `BETWEEN_501_AND_2000`, `BETWEEN_2001_AND_10000`, `MORE_THAN_10001`.

## Tests / fixtures
- Added `number_of_employees` to `profileGetResponse.json` mock and asserted deserialization in `TestProfile.cs`, mirroring the DBA assertion.

## Version
- Bumped patch `5.52.1` -> `5.52.2` in `Plivo.csproj`, `Plivo.nuspec`, and `version.json`.
- Added CHANGELOG entry at top (2026-06-10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)