### PR TITLE
feat: add complianceApplicationId param to phone number Buy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## [5.52.2](https://github.com/plivo/plivo-dotnet/tree/v5.52.2) (2026-06-11)
+**Feature - PhoneNumber Buy compliance application support**
+- Added optional `complianceApplicationId` parameter to PhoneNumber `Buy` and `BuyAsync` methods, sent as `compliance_application_id`, to link a regulatory compliance application at purchase time for regulated numbers
+
 ## [5.52.1](https://github.com/plivo/plivo-dotnet/tree/v5.52.1) (2026-05-26)
 **Feature - Profile API DBA field support**
 - Added Doing Business As (DBA) field support to Profile API

--- a/src/Plivo/Plivo.csproj
+++ b/src/Plivo/Plivo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.3</TargetFrameworks>
-    <ReleaseVersion>5.52.1</ReleaseVersion>
+    <ReleaseVersion>5.52.2</ReleaseVersion>
     <Version />
     <Authors>Plivo SDKs Team</Authors>
     <Owners>Plivo Inc.</Owners>

--- a/src/Plivo/Plivo.nuspec
+++ b/src/Plivo/Plivo.nuspec
@@ -4,7 +4,7 @@
     <summary>A .NET SDK to make voice calls and send SMS using Plivo and to generate Plivo XML</summary>
     <description>A .NET SDK to make voice calls and send SMS using Plivo and to generate Plivo XML</description>
     <id>Plivo</id>
-    <version>5.52.1</version>
+    <version>5.52.2</version>
     <title>Plivo</title>
     <authors>Plivo SDKs Team</authors>
     <owners>Plivo, Inc.</owners>

--- a/src/Plivo/Resource/PhoneNumber/PhoneNumberInterface.cs
+++ b/src/Plivo/Resource/PhoneNumber/PhoneNumberInterface.cs
@@ -134,12 +134,14 @@ namespace Plivo.Resource.PhoneNumber
         /// <param name="verificationInfo">Verification information. address_id and identity_id are the keys</param>
         /// <param name="cnamLookup">Cnam Lookup</param>
         /// <param name="haEnabled">HA Enabled</param>
+        /// <param name="complianceApplicationId">Compliance Application Id</param>
         public PhoneNumberBuyResponse Buy(string number, string appId = null, string cnamLookup = null,
-                                          Dictionary<string, string> verificationInfo = null, bool? haEnabled = null)
+                                          Dictionary<string, string> verificationInfo = null, bool? haEnabled = null,
+                                          string complianceApplicationId = null)
         {
             var mandatoryParams = new List<string> {""};
             var data = CreateData(
-                mandatoryParams, new {appId, verificationInfo, cnamLookup, haEnabled});
+                mandatoryParams, new {appId, verificationInfo, cnamLookup, haEnabled, complianceApplicationId});
 
 			return ExecuteWithExceptionUnwrap(() =>
 			{
@@ -161,12 +163,14 @@ namespace Plivo.Resource.PhoneNumber
         /// <param name="verificationInfo">Verification information. address_id and identity_id are the keys</param>
         /// <param name="cnamLookup">Cnam Lookup</param>
         /// <param name="haEnabled">HA Enabled</param>
+        /// <param name="complianceApplicationId">Compliance Application Id</param>
         public async Task<PhoneNumberBuyResponse> BuyAsync(string number, string appId = null, string cnamLookup = null,
-                                          Dictionary<string, string> verificationInfo = null, bool? haEnabled = null)
+                                          Dictionary<string, string> verificationInfo = null, bool? haEnabled = null,
+                                          string complianceApplicationId = null)
         {
             var mandatoryParams = new List<string> { "" };
             var data = CreateData(
-                mandatoryParams, new { appId, verificationInfo, cnamLookup, haEnabled });
+                mandatoryParams, new { appId, verificationInfo, cnamLookup, haEnabled, complianceApplicationId });
             var result = await Client.Update<PhoneNumberBuyResponse>(
                   Uri + number + "/",
                   data

--- a/tests/Plivo.Test/Resources/TestPhoneNumber.cs
+++ b/tests/Plivo.Test/Resources/TestPhoneNumber.cs
@@ -71,5 +71,37 @@ namespace Plivo.Test.Resources
 
             AssertRequest(request);
         }
+
+        [Test]
+        public void TestPhoneNumberBuyWithComplianceApplicationId()
+        {
+            var id = "abcabcabc";
+            var data = new Dictionary<string, object>()
+            {
+                {"app_id", "123"},
+                {"compliance_application_id", "compAppId123"}
+            };
+            var request =
+                new PlivoRequest(
+                    "POST",
+                    "Account/MAXXXXXXXXXXXXXXXXXX/PhoneNumber/" + id + "/",
+                    "",
+                    data);
+
+            var response =
+                System.IO.File.ReadAllText(
+                    SOURCE_DIR + @"Mocks/phoneNumberCreateResponse.json"
+                );
+            Setup<PhoneNumberBuyResponse>(
+                201,
+                response
+            );
+            Assert.IsEmpty(
+                ComparisonUtilities.Compare(
+                    response,
+                    Api.PhoneNumber.Buy(id, "123", complianceApplicationId: "compAppId123")));
+
+            AssertRequest(request);
+        }
     }
 }

--- a/tests_netcore/Plivo.NetCore.Test/Resources/TestPhoneNumber.cs
+++ b/tests_netcore/Plivo.NetCore.Test/Resources/TestPhoneNumber.cs
@@ -70,5 +70,37 @@ namespace Plivo.NetCore.Test.Resources
 
             AssertRequest(request);
         }
+
+        [Fact]
+        public void TestPhoneNumberBuyWithComplianceApplicationId()
+        {
+            var id = "abcabcabc";
+            var data = new Dictionary<string, object>()
+            {
+                {"app_id", "123"},
+                {"compliance_application_id", "compAppId123"}
+            };
+            var request =
+                new PlivoRequest(
+                    "POST",
+                    "Account/MAXXXXXXXXXXXXXXXXXX/PhoneNumber/" + id + "/",
+                    "",
+                    data);
+
+            var response =
+                System.IO.File.ReadAllText(
+                    SOURCE_DIR + @"../Mocks/phoneNumberCreateResponse.json"
+                );
+            Setup<PhoneNumberBuyResponse>(
+                201,
+                response
+            );
+            Assert.Empty(
+                ComparisonUtilities.Compare(
+                    response,
+                    Api.PhoneNumber.Buy(id, "123", complianceApplicationId: "compAppId123")));
+
+            AssertRequest(request);
+        }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.52.1",
+  "version": "5.52.2",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
## What
Adds an optional trailing `complianceApplicationId` parameter to `PhoneNumber.Buy` and `PhoneNumber.BuyAsync`. It is serialized to the `compliance_application_id` wire parameter. Previously `Buy` only sent `app_id`, `cnam_lookup`, and `ha_enabled`.

## Why
Regulated numbers (e.g. India) require an approved regulatory compliance application to be linked at purchase time. This lets callers pass that application id directly when buying the number.

## Notes
- Backward-compatible: the new parameter is a trailing optional param, so existing callers are unaffected.
- Covers both `Buy` and `BuyAsync`.
- Adds tests in both the NUnit (`tests/Plivo.Test`) and xUnit (`tests_netcore/Plivo.NetCore.Test`) suites asserting the `compliance_application_id` payload.
- Version bumped to 5.52.2 across `version.json`, `Plivo.csproj`, `Plivo.nuspec`, plus a CHANGELOG entry.
- Verified on a .NET 10 test harness (PhoneNumber tests pass). The repo's EOL target frameworks plus Nerdbank.GitVersioning's x86_64 libgit2 cannot run locally on this arm64 machine, a known pre-existing environment limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)