### PR TITLE
feat(tollfree-verification): add optional terms, privacy, opt-in and help parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## [5.52.3](https://github.com/plivo/plivo-dotnet/tree/v5.52.3) (2026-07-27)
+**Feature - Toll-free verification terms, privacy, opt-in and help fields**
+- Added optional `termsAndConditionsLink`, `privacyPolicyLink`, `optinMessage` and `helpMessage` parameters to the toll-free verification create and update methods
+
 ## [5.52.2](https://github.com/plivo/plivo-dotnet/tree/v5.52.2) (2026-06-11)
 **Feature - PhoneNumber Buy compliance application support**
 - Added optional `complianceApplicationId` parameter to PhoneNumber `Buy` and `BuyAsync` methods, sent as `compliance_application_id`, to link a regulatory compliance application at purchase time for regulated numbers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
-## [5.52.3](https://github.com/plivo/plivo-dotnet/tree/v5.52.3) (2026-07-27)
+## [5.52.3](https://github.com/plivo/plivo-dotnet/tree/v5.52.3) (2026-07-28)
 **Feature - Toll-free verification terms, privacy, opt-in and help fields**
 - Added optional `termsAndConditionsLink`, `privacyPolicyLink`, `optinMessage` and `helpMessage` parameters to the toll-free verification create and update methods
 

--- a/src/Plivo/Plivo.nuspec
+++ b/src/Plivo/Plivo.nuspec
@@ -4,7 +4,7 @@
     <summary>A .NET SDK to make voice calls and send SMS using Plivo and to generate Plivo XML</summary>
     <description>A .NET SDK to make voice calls and send SMS using Plivo and to generate Plivo XML</description>
     <id>Plivo</id>
-    <version>5.52.2</version>
+    <version>5.52.3</version>
     <title>Plivo</title>
     <authors>Plivo SDKs Team</authors>
     <owners>Plivo, Inc.</owners>

--- a/src/Plivo/Resource/TollfreeVerification/TollfreeVerificationInterface.cs
+++ b/src/Plivo/Resource/TollfreeVerification/TollfreeVerificationInterface.cs
@@ -39,7 +39,8 @@ namespace Plivo.Resource.TollfreeVerification
             string profileUuid, string number, string usecase,
             string usecaseSummary, string messageSample, string optinImageUrl, string optinType,
             string volume, string additionalInformation = null, string extraData = null, string callbackUrl = null,
-            string callbackMethod = null)
+            string callbackMethod = null, string termsAndConditionsLink = null, string privacyPolicyLink = null,
+            string optinMessage = null, string helpMessage = null)
         {
             var mandatoryParams = new List<string>
             {
@@ -60,7 +61,11 @@ namespace Plivo.Resource.TollfreeVerification
                     additionalInformation,
                     extraData,
                     callbackUrl,
-                    callbackMethod
+                    callbackMethod,
+                    termsAndConditionsLink,
+                    privacyPolicyLink,
+                    optinMessage,
+                    helpMessage
                 });
             return ExecuteWithExceptionUnwrap(() =>
             {
@@ -96,7 +101,8 @@ namespace Plivo.Resource.TollfreeVerification
             string profileUuid, string number, string usecase,
             string usecaseSummary, string messageSample, string optinImageUrl, string optinType,
             string volume, string additionalInformation = null, string extraData = null, string callbackUrl = null,
-            string callbackMethod = null)
+            string callbackMethod = null, string termsAndConditionsLink = null, string privacyPolicyLink = null,
+            string optinMessage = null, string helpMessage = null)
         {
             var mandatoryParams = new List<string>
             {
@@ -118,7 +124,11 @@ namespace Plivo.Resource.TollfreeVerification
                     additionalInformation,
                     extraData,
                     callbackUrl,
-                    callbackMethod
+                    callbackMethod,
+                    termsAndConditionsLink,
+                    privacyPolicyLink,
+                    optinMessage,
+                    helpMessage
                 });
 
 
@@ -303,7 +313,9 @@ namespace Plivo.Resource.TollfreeVerification
             string messageSample = null,
             string optinImageUrl = null, string optinType = null, string volume = null,
             string additionalInformation = null,
-            string extraData = null, string callbackUrl = null, string callbackMethod = null)
+            string extraData = null, string callbackUrl = null, string callbackMethod = null,
+            string termsAndConditionsLink = null, string privacyPolicyLink = null,
+            string optinMessage = null, string helpMessage = null)
         {
             var mandatoryParams = new List<string> { "" };
             var data = CreateData(
@@ -321,7 +333,11 @@ namespace Plivo.Resource.TollfreeVerification
                     additionalInformation,
                     extraData,
                     callbackUrl,
-                    callbackMethod
+                    callbackMethod,
+                    termsAndConditionsLink,
+                    privacyPolicyLink,
+                    optinMessage,
+                    helpMessage
                 });
 
             return ExecuteWithExceptionUnwrap(() =>
@@ -357,7 +373,9 @@ namespace Plivo.Resource.TollfreeVerification
             string messageSample = null,
             string optinImageUrl = null, string optinType = null, string volume = null,
             string additionalInformation = null,
-            string extraData = null, string callbackUrl = null, string callbackMethod = null)
+            string extraData = null, string callbackUrl = null, string callbackMethod = null,
+            string termsAndConditionsLink = null, string privacyPolicyLink = null,
+            string optinMessage = null, string helpMessage = null)
         {
             MpcUtils.ValidUrl("callbackUrl", callbackUrl, true);
             var mandatoryParams = new List<string> { "" };
@@ -376,7 +394,11 @@ namespace Plivo.Resource.TollfreeVerification
                     additionalInformation,
                     extraData,
                     callbackUrl,
-                    callbackMethod
+                    callbackMethod,
+                    termsAndConditionsLink,
+                    privacyPolicyLink,
+                    optinMessage,
+                    helpMessage
                 });
             var result = Task.Run(async () =>
                 await Client.Update<AsyncResponse>(Uri + uuid + "/", data).ConfigureAwait(false)).Result;

--- a/tests_netcore/Plivo.NetCore.Test/Resources/TestTollfreeVerification.cs
+++ b/tests_netcore/Plivo.NetCore.Test/Resources/TestTollfreeVerification.cs
@@ -27,6 +27,10 @@ namespace Plivo.NetCore.Test.Resources
                 { "callback_method", "GET" },
                 { "additional_information", "test additional information" },
                 { "extra_data", "test extradata" },
+                { "terms_and_conditions_link", "https://www.test.com/terms" },
+                { "privacy_policy_link", "https://www.test.com/privacy" },
+                { "optin_message", "test optin message" },
+                { "help_message", "test help message" },
             };
             var request =
                 new PlivoRequest(
@@ -55,7 +59,11 @@ namespace Plivo.NetCore.Test.Resources
                         "test additional information",
                         "test extradata",
                         "https://testcallback.com",
-                        "GET"
+                        "GET",
+                        "https://www.test.com/terms",
+                        "https://www.test.com/privacy",
+                        "test optin message",
+                        "test help message"
                     )
                 ));
             AssertRequest(request);
@@ -78,6 +86,10 @@ namespace Plivo.NetCore.Test.Resources
                 { "callback_method", "POST" },
                 { "additional_information", "test additional information" },
                 { "extra_data", "test extradata" },
+                { "terms_and_conditions_link", "https://www.test.com/terms" },
+                { "privacy_policy_link", "https://www.test.com/privacy" },
+                { "optin_message", "test optin message" },
+                { "help_message", "test help message" },
             };
             var request =
                 new PlivoRequest(
@@ -106,7 +118,11 @@ namespace Plivo.NetCore.Test.Resources
                         "test additional information",
                         "test extradata",
                         "https://testcallback.com",
-                        "POST"
+                        "POST",
+                        "https://www.test.com/terms",
+                        "https://www.test.com/privacy",
+                        "test optin message",
+                        "test help message"
                     ).Result
                 ));
             AssertRequest(request);
@@ -234,6 +250,10 @@ namespace Plivo.NetCore.Test.Resources
                 { "callback_url", "http://updated.callback.url" },
                 { "callback_method", "POST" },
                 { "usecase", "2FA" },
+                { "terms_and_conditions_link", "https://www.test.com/terms" },
+                { "privacy_policy_link", "https://www.test.com/privacy" },
+                { "optin_message", "test optin message" },
+                { "help_message", "test help message" },
             };
 
             var request =
@@ -255,7 +275,9 @@ namespace Plivo.NetCore.Test.Resources
                 ComparisonUtilities.Compare(
                     response,
                     Api.TollfreeVerification.Update(uuid, usecase: "2FA", callbackUrl: "http://updated.callback.url",
-                        callbackMethod: "POST")));
+                        callbackMethod: "POST", termsAndConditionsLink: "https://www.test.com/terms",
+                        privacyPolicyLink: "https://www.test.com/privacy", optinMessage: "test optin message",
+                        helpMessage: "test help message")));
             AssertRequest(request);
         }
 
@@ -268,6 +290,10 @@ namespace Plivo.NetCore.Test.Resources
                 { "callback_url", "http://updated.callback.url" },
                 { "callback_method", "POST" },
                 { "usecase", "2FA" },
+                { "terms_and_conditions_link", "https://www.test.com/terms" },
+                { "privacy_policy_link", "https://www.test.com/privacy" },
+                { "optin_message", "test optin message" },
+                { "help_message", "test help message" },
             };
 
             var request =
@@ -286,7 +312,10 @@ namespace Plivo.NetCore.Test.Resources
                 ComparisonUtilities.Compare(
                     response,
                     Api.TollfreeVerification.UpdateAsync(uuid, usecase: "2FA",
-                        callbackUrl: "http://updated.callback.url", callbackMethod: "POST").Result
+                        callbackUrl: "http://updated.callback.url", callbackMethod: "POST",
+                        termsAndConditionsLink: "https://www.test.com/terms",
+                        privacyPolicyLink: "https://www.test.com/privacy", optinMessage: "test optin message",
+                        helpMessage: "test help message").Result
                 )
             );
             AssertRequest(request);

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.52.2",
+  "version": "5.52.3",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
## Summary

Adds four new **optional** parameters to the toll-free verification create and update APIs:

| Parameter | Max length |
|---|---|
| `terms_and_conditions_link` | 2000 |
| `privacy_policy_link` | 2000 |
| `optin_message` | 500 |
| `help_message` | 500 |

## Backward compatibility

All four parameters are optional. Existing calls are unaffected — omitting them produces exactly the same request as before.

## Tests

Existing toll-free verification tests are extended to cover the new parameters on both create and update.