### PR TITLE
feat: add internal flag to Endpoint create params (VT-9534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Change Log
+## [5.52.4](https://github.com/plivo/plivo-dotnet/tree/v5.52.4) (2026-07-27)
+**Feature - Endpoint internal flag support**
+- Added optional `isInternal` (bool?) parameter to Endpoint `Create` and `CreateAsync` methods, sent as `internal` on the wire, to mark newly created SIP endpoints as internal at creation time
+- C# reserved-keyword workaround: parameter is named `isInternal` because `internal` is a C# keyword; the outgoing JSON key is still `internal`
+
 ## [5.52.2](https://github.com/plivo/plivo-dotnet/tree/v5.52.2) (2026-06-11)
 **Feature - PhoneNumber Buy compliance application support**
 - Added optional `complianceApplicationId` parameter to PhoneNumber `Buy` and `BuyAsync` methods, sent as `compliance_application_id`, to link a regulatory compliance application at purchase time for regulated numbers

--- a/src/Plivo/Plivo.csproj
+++ b/src/Plivo/Plivo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.3</TargetFrameworks>
-    <ReleaseVersion>5.52.2</ReleaseVersion>
+    <ReleaseVersion>5.52.4</ReleaseVersion>
     <Version />
     <Authors>Plivo SDKs Team</Authors>
     <Owners>Plivo Inc.</Owners>

--- a/src/Plivo/Plivo.nuspec
+++ b/src/Plivo/Plivo.nuspec
@@ -4,7 +4,7 @@
     <summary>A .NET SDK to make voice calls and send SMS using Plivo and to generate Plivo XML</summary>
     <description>A .NET SDK to make voice calls and send SMS using Plivo and to generate Plivo XML</description>
     <id>Plivo</id>
-    <version>5.52.2</version>
+    <version>5.52.4</version>
     <title>Plivo</title>
     <authors>Plivo SDKs Team</authors>
     <owners>Plivo, Inc.</owners>

--- a/src/Plivo/Resource/Endpoint/EndpointInterface.cs
+++ b/src/Plivo/Resource/Endpoint/EndpointInterface.cs
@@ -32,8 +32,10 @@ namespace Plivo.Resource.Endpoint
         /// <param name="password">Password.</param>
         /// <param name="alias">Alias.</param>
         /// <param name="appId">App identifier.</param>
+        /// <param name="isInternal">Optional flag to mark the endpoint as internal. Serialized as <c>internal</c> on the wire (the C# keyword <c>internal</c> cannot be used as a parameter name).</param>
         public EndpointCreateResponse Create(
-            string username, string password, string alias, string appId = null)
+            string username, string password, string alias, string appId = null,
+            bool? isInternal = null)
         {
             var mandatoryParams = new List<string> { "" };
             bool isVoiceRequest = true;
@@ -47,6 +49,9 @@ namespace Plivo.Resource.Endpoint
                     appId,
                     isVoiceRequest
                 });
+            if (isInternal.HasValue) {
+                data["internal"] = isInternal.Value;
+            }
 
             return ExecuteWithExceptionUnwrap(() =>
             {
@@ -66,9 +71,11 @@ namespace Plivo.Resource.Endpoint
         /// <param name="appId">App identifier.</param>
         /// <param name="callbackUrl">Callback URL.</param>
         /// <param name="callbackMethod">Callback Method.</param>
+        /// <param name="isInternal">Optional flag to mark the endpoint as internal. Serialized as <c>internal</c> on the wire (the C# keyword <c>internal</c> cannot be used as a parameter name).</param>
         public async Task<AsyncResponse> CreateAsync(
             string username, string password, string alias, string appId = null,
-            string callbackUrl = null, string callbackMethod = null)
+            string callbackUrl = null, string callbackMethod = null,
+            bool? isInternal = null)
         {
             MpcUtils.ValidUrl("callbackUrl", callbackUrl, true);
             var mandatoryParams = new List<string> { "" };
@@ -87,6 +94,9 @@ namespace Plivo.Resource.Endpoint
                 });
             if (data.ContainsKey("callback_method") && callbackMethod == null) {
                 data.Remove("callback_method");
+            }
+            if (isInternal.HasValue) {
+                data["internal"] = isInternal.Value;
             }
             var result = Task.Run(async () => await Client.Update<AsyncResponse>(Uri, data).ConfigureAwait(false)).Result;
             await Task.WhenAll();

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.52.2",
+  "version": "5.52.4",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
## Summary

Adds an optional `isInternal` (`bool?`) parameter to `EndpointInterface.Create` and `CreateAsync` so callers can mark newly created SIP endpoints as internal at creation time.

## Why

Plivo CX (Contacto) auto-creates a SIP endpoint per AOM during user invite for browser-SDK playback. These internal endpoints currently leak into the customer's Endpoints tab in the console (Pylon #2460), causing confusion, prod alerts (customers try to register the SIP from third-party clients), and a security concern (customer can silently change creds).

The **trace** service already supports an `internal` column on the endpoint model + defaults the List API to exclude internal endpoints (commit `cea50cf` / `d425930` on trace). What's missing is the ability for the auto-create call (Hodor) to actually mark endpoints as `internal=true` at creation time. This SDK change unblocks that.

## Change

- `src/Plivo/Resource/Endpoint/EndpointInterface.cs` — one new optional parameter on both `Create` and `CreateAsync`: `bool? isInternal = null`.
- When `isInternal.HasValue`, the value is added directly to the outgoing request dictionary under the wire key `internal` (lowercase) — bypassing the anonymous-object -> snake_case conversion done by `CreateData`, which would otherwise emit `is_internal`.

### C# reserved-keyword workaround

`internal` is a C# keyword and cannot be used as a parameter identifier, so the SDK-facing parameter is `isInternal`. The value is stamped onto the request body with `data["internal"] = isInternal.Value;` so the wire contract (`internal`) still matches the Trace backend and the other-language SDKs.

## Backwards-compatibility

Optional nullable parameter, default `null`. When `isInternal` is `null`, the key is omitted from the request body entirely — every existing caller sees identical wire behavior. Only callers that explicitly pass `isInternal: true` opt into the new path.

## Test plan

- [ ] `dotnet build src/Plivo/Plivo.csproj` clean (not runnable in this env — no local dotnet installed; verify in CI)
- [ ] Existing Endpoint tests pass
- [ ] End-to-end sanity: call Endpoint `Create` with `isInternal: true` against `api.plivo.com` from a test account and verify `subscriber.internal = true` on the row (validated separately by the CX team's integration)

## Related

- JIRA: VT-9534
- Slack: [thread on Pylon #2460]
- Companion PRs across other SDKs: plivo-go #250, plivo-python, plivo-node, plivo-ruby, plivo-java, plivo-php (following this pattern)

Generated with [Claude Code](https://claude.com/claude-code)