### PR TITLE
feat(caller-reputation): support profile-first Caller Reputation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Change Log
+## [5.53.0](https://github.com/plivo/plivo-dotnet/tree/v5.53.0) (2026-08-06)
+**Feature - Caller Reputation profile-first API**
+- Added optional `enable_caller_reputation`, `vetting_provider`, `callback_url` and `callback_method` parameters to `Profile.Update` and `Profile.UpdateAsync`, serialized to the matching wire keys
+- `vetting_provider` accepts the customer-facing carrier keys `"at&t"` and `"t-mobile"` (case-insensitive on the API side)
+- Single profile-level callback URL replaces the earlier per-carrier `callbacks` map; Update Number is now attach-only for CR and never registers a new business
+- Backward-compatible additive optional parameters
+
 ## [5.52.3](https://github.com/plivo/plivo-dotnet/tree/v5.52.3) (2026-07-28)
 **Feature - Toll-free verification terms, privacy, opt-in and help fields**
 - Added optional `termsAndConditionsLink`, `privacyPolicyLink`, `optinMessage` and `helpMessage` parameters to the toll-free verification create and update methods

--- a/src/Plivo/Plivo.csproj
+++ b/src/Plivo/Plivo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.3</TargetFrameworks>
-    <ReleaseVersion>5.52.2</ReleaseVersion>
+    <ReleaseVersion>5.53.0</ReleaseVersion>
     <Version />
     <Authors>Plivo SDKs Team</Authors>
     <Owners>Plivo Inc.</Owners>

--- a/src/Plivo/Plivo.nuspec
+++ b/src/Plivo/Plivo.nuspec
@@ -4,7 +4,7 @@
     <summary>A .NET SDK to make voice calls and send SMS using Plivo and to generate Plivo XML</summary>
     <description>A .NET SDK to make voice calls and send SMS using Plivo and to generate Plivo XML</description>
     <id>Plivo</id>
-    <version>5.52.3</version>
+    <version>5.53.0</version>
     <title>Plivo</title>
     <authors>Plivo SDKs Team</authors>
     <owners>Plivo, Inc.</owners>

--- a/src/Plivo/Resource/Profile/ProfileInterface.cs
+++ b/src/Plivo/Resource/Profile/ProfileInterface.cs
@@ -227,7 +227,8 @@ namespace Plivo.Resource.Profile
 
         public GetProfile Update(string profile_uuid, string company_name =null,  string website = null,
             string entity_type=null, string vertical= null,  AuthorizedContact authorized_contact=null, Address address=null, string business_contact_email = null,
-            string ein = null, string ein_issuing_country = null, string alt_business_id = null, string alt_business_id_type = null, string doing_business_as = null)
+            string ein = null, string ein_issuing_country = null, string alt_business_id = null, string alt_business_id_type = null, string doing_business_as = null,
+            bool? enable_caller_reputation = null, List<string> vetting_provider = null, string callback_url = null, string callback_method = null)
         {
              var mandatoryParams = new List<string>{"profile_uuid"};
         var data = CreateData(
@@ -245,7 +246,11 @@ namespace Plivo.Resource.Profile
                 ein_issuing_country,
                 alt_business_id,
                 alt_business_id_type,
-                doing_business_as
+                doing_business_as,
+                enable_caller_reputation,
+                vetting_provider,
+                callback_url,
+                callback_method
             });
 		return ExecuteWithExceptionUnwrap(() =>
 		{
@@ -270,7 +275,8 @@ namespace Plivo.Resource.Profile
         /// <param name="business_contact_email">business_contact_email</param>
 		public async Task<ProfileResponse> UpdateAsync(string profile_uuid, string company_name =null,  string website = null,
             string entity_type=null, string vertical= null,  AuthorizedContact authorized_contact=null, Address address=null, string business_contact_email = null,
-            string ein = null, string ein_issuing_country = null, string alt_business_id = null, string alt_business_id_type = null, string doing_business_as = null)
+            string ein = null, string ein_issuing_country = null, string alt_business_id = null, string alt_business_id_type = null, string doing_business_as = null,
+            bool? enable_caller_reputation = null, List<string> vetting_provider = null, string callback_url = null, string callback_method = null)
         {
              var mandatoryParams = new List<string>{"profile_uuid"};
         var data = CreateData(
@@ -288,7 +294,11 @@ namespace Plivo.Resource.Profile
                 ein_issuing_country,
                 alt_business_id,
                 alt_business_id_type,
-                doing_business_as
+                doing_business_as,
+                enable_caller_reputation,
+                vetting_provider,
+                callback_url,
+                callback_method
             });
 			var result = await Client.Update<ProfileResponse>(Uri + "Profile/"+profile_uuid+"/", data);
             result.Object.StatusCode = result.StatusCode;

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.52.3",
+  "version": "5.53.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
## Summary

- Adds four optional parameters to `Profile.Update` and `Profile.UpdateAsync` for the new profile-first Caller Reputation wire shape: `enable_caller_reputation`, `vetting_provider`, `callback_url`, `callback_method`
- Parameter names match the wire keys verbatim (matches how `Profile.Update` already spells its other params like `company_name`, `entity_type`)
- Bumps to `5.53.0`; the bump commit updates **all three** version files together (`version.json`, `Plivo.nuspec`, `Plivo.csproj <ReleaseVersion>`) to prevent the drift that produced fixup commits `7f3be23` and `085669a`

## Post-review wire shape

```csharp
var response = plivo.Api.Profile.Update(
    profile_uuid: profileUuid,
    enable_caller_reputation: true,
    vetting_provider: new List<string> { "at&t", "t-mobile" },
    callback_url: "https://example.com/cr/webhook",
    callback_method: "POST"
);
```

- `vetting_provider` values are the customer-facing carrier keys `"at&t"` and `"t-mobile"` (case-insensitive on the API side; canonical lowercase in storage).
- Single profile-level callback URL replaces the earlier per-carrier `callbacks: {carrier: {url, method}}` map.
- Update Number is now attach-only for Caller Reputation — never calls `RegisterBusiness` in any case (approved, pending, failed, missing).

## Notes

- No test added: `TestProfile.cs` has no existing `TestProfileUpdate` scaffolding — adding one would require a new mock JSON fixture. The zipwhip TF PR added tests only where a Create test already existed; matching that convention here. Maintainer team can add a test in a follow-up if they prefer scaffolding first.

## Test plan

- [ ] `dotnet build src/Plivo/Plivo.csproj` — clean
- [ ] `dotnet test` — existing suite unaffected
- [ ] Manual: `plivo.Api.Profile.Update(uuid, enable_caller_reputation: true, vetting_provider: new List<string> { "at&t" }, callback_url: "https://…", callback_method: "POST")` returns 200 with `caller_reputation_status` in the response
- [ ] `SELECT caller_reputation_callback_url, caller_reputation_callback_method FROM plivo_account_profile WHERE profile_uuid = ...` shows the values landed in dbcfg
- [ ] Confirm `version.json`, `Plivo.nuspec` and `Plivo.csproj <ReleaseVersion>` all read `5.53.0` (no drift on the way in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)